### PR TITLE
Fixed Safari video issues

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,7 +26,7 @@ function App() {
   const [facingMode, setFacingMode] = useState("user")
 
   // device info
-  const { videoDevices } = useMediaDeviceInfo()
+  const { videoInputDevices } = useMediaDeviceInfo()
 
   // App UI state
   const [activeModal, setActiveModal] = useState(modalConsts.NONE)
@@ -67,7 +67,7 @@ function App() {
         setFacingMode={setFacingMode}
         debug={debug}
         setDebug={setDebug}
-        videoDeviceCount={videoDevices.length}
+        videoDeviceCount={videoInputDevices.length}
       />
       <main style={{ display: "flex", height: "92vh", alignItems: "center" }}>
         <EmojiVision

--- a/src/hooks/useDeviceDimensions.js
+++ b/src/hooks/useDeviceDimensions.js
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 
 export const useDeviceDimensions = () => {
-  const [videoDevices, setVideoDevices] = useState([])
   const [orientation, setOrientation] = useState(null)
   const [screenWidth, setScreenWidth] = useState(0)
   const [screenHeight, setScreenHeight] = useState(0)
@@ -9,28 +8,23 @@ export const useDeviceDimensions = () => {
   useEffect(() => {
     const onDeviceOrientation = () => {
       const orientation = (window.screen.orientation || {}).type || window.screen.mozOrientation || window.screen.msOrientation
+
       setScreenWidth(window.screen.width)
       setScreenHeight(window.screen.height)
-      if (orientation.includes("landscape")) {
-        setOrientation("landscape")
-      } else {
+      if (orientation && orientation.includes("portrait")) {
         setOrientation("portrait")
+      } else {
+        setOrientation("landscape")
       }
     }
 
     window.addEventListener("deviceorientation", onDeviceOrientation)
-
-    navigator.mediaDevices.enumerateDevices()
-      .then(devices => {
-        const videoDevices = devices.filter(device => device.kind === "videoinput")
-        setVideoDevices(videoDevices)
-        onDeviceOrientation()
-      })
+    onDeviceOrientation()
 
     return () => {
       window.removeEventListener("deviceorientation", onDeviceOrientation)
     }
   }, [])
 
-  return { videoDevices, orientation, screenWidth, screenHeight }
+  return { orientation, screenWidth, screenHeight }
 }

--- a/src/hooks/useMediaDeviceInfo.js
+++ b/src/hooks/useMediaDeviceInfo.js
@@ -1,30 +1,35 @@
 import { useState, useEffect } from 'react'
 
 export const useMediaDeviceInfo = () => {
-  const [videoDevices, setVideoDevices] = useState([])
+  const [videoInputDevices, setVideoInputDevices] = useState([])
   const [audioInputDevices, setAudioInputDevices] = useState([])
   const [audioOutputDevices, setAudioOutputDevices] = useState([])
 
   useEffect(() => {
     (async () => {
+      // getUserMedia to ensure devices are available for enumeration in Safari
+      await navigator.mediaDevices.getUserMedia({ audio: false, video: true })
+
       const devices = await navigator.mediaDevices.enumerateDevices()
-      const videoDevices = []
+      const videoInputDevices = []
       const audioInputDevices = []
       const audioOutputDevices = []
+
       devices.forEach(device => {
         if (device.kind === "videoinput") {
-          videoDevices.push(device)
+          videoInputDevices.push(device)
         } else if (device.kind === "audioinput") {
           audioInputDevices.push(device)
         } else if (device.kind === "audiooutput") {
           audioOutputDevices.push(device)
         }
       })
-      setVideoDevices(videoDevices)
+
+      setVideoInputDevices(videoInputDevices)
       setAudioInputDevices(audioInputDevices)
       setAudioOutputDevices(audioOutputDevices)
     })()
   }, [])
 
-  return { videoDevices, audioInputDevices, audioOutputDevices }
+  return { videoInputDevices, audioInputDevices, audioOutputDevices }
 }

--- a/src/hooks/usePixelatedVideo.js
+++ b/src/hooks/usePixelatedVideo.js
@@ -60,7 +60,6 @@ export const usePixelatedVideo = ({
         })
         pixelData = quant.reduce(pixelData)
 
-
         setImageData(pixelData)
       }
     }
@@ -94,6 +93,9 @@ export const usePixelatedVideo = ({
       if (video.srcObject !== mediaStream) {
         video.srcObject = mediaStream
         video.autoplay = true
+        video.oncanplay = () => {
+          video.play()
+        }
 
         video.onloadeddata = () => {
           setVideoWidth(video.videoWidth)


### PR DESCRIPTION
Added call to getUserMedia before enumerateDevices; also call play() on video element when video is ready.

Fixes #6 